### PR TITLE
BUGFIX Make sure site homepages are loaded at root

### DIFF
--- a/code/controllers/MultisitesRootController.php
+++ b/code/controllers/MultisitesRootController.php
@@ -54,5 +54,33 @@ class MultisitesRootController extends RootURLController {
 			return new SS_HTTPResponse(null, 404);
 		}
 	}
+	
+	/**
+	 * The the (relative) homepage link.
+	 * TODO: Should this deal with HomepageForDomain and Translatable the same way the core equivalent does?
+	 * 
+	 * @return string
+	 */
+	public static function get_homepage_link() {
+		return self::$default_homepage_link;
+	}
+	
+	/**
+	 * Returns TRUE if a request to a certain page should be redirected to the site root (i.e. if the page acts as the
+	 * home page).
+	 * 
+	 * TODO: This function wouldn't be required if core called static::get_homepage_link() rather than self::get_homepage_link(). Raise a bug?
+	 *
+	 * @param SiteTree $page
+	 * @return bool
+	 */
+	public static function should_be_on_root(SiteTree $page) {
+		if(!self::$is_at_root && self::get_homepage_link() == trim($page->RelativeLink(true), '/')) {
+			return !(
+				class_exists('Translatable') && $page->hasExtension('Translatable') && $page->Locale && $page->Locale != Translatable::default_locale()
+			);
+		}
+		return false;
+	}
 
 }

--- a/code/extensions/MultisitesSiteTreeExtension.php
+++ b/code/extensions/MultisitesSiteTreeExtension.php
@@ -35,6 +35,24 @@ class MultisitesSiteTreeExtension extends SiteTreeExtension {
 
 		$fields->dataFieldByName('URLSegment')->setURLPrefix($url);
 	}
+	
+	/**
+	 * Make sure site home pages are loaded at the root of the site.
+	 */
+	public function contentcontrollerInit($controller) {
+		
+		// If we've accessed the homepage as /home/, then we should redirect to /.
+		if($controller->dataRecord && $controller->dataRecord instanceof SiteTree
+			 	&& MultisitesRootController::should_be_on_root($controller->dataRecord) && (!isset($controller->urlParams['Action']) || !$controller->urlParams['Action'] ) 
+				&& !$_POST && !$_FILES && !$controller->redirectedTo() ) {
+			$getVars = $_GET;
+			unset($getVars['url']);
+			if($getVars) $url = "?" . http_build_query($getVars);
+			else $url = "";
+			$controller->redirect($url, 301);
+			return;
+		}
+	}
 
 	public function onBeforeWrite() {
 		if(!$this->owner->SiteID) {


### PR DESCRIPTION
The core implementation of this only works for the default Site object. This applies to all Site records.
