### PR TITLE
Allow editing of site title in settings screen.

### DIFF
--- a/code/extensions/MultisitesSiteConfigExtension.php
+++ b/code/extensions/MultisitesSiteConfigExtension.php
@@ -11,7 +11,6 @@ class MultisitesSiteConfigExtension extends Extension {
 	 * @param FieldList $fields The SiteConfig fields
 	 */
 	public function updateCMSFields($fields) {
-		$fields->removeByName('Title');
 		$fields->removeByName('Tagline');
 		$fields->removeByName('Theme');
 	}


### PR DESCRIPTION
It should be possible to edit the site title in the CMS settings screen. Even if the title isn't used on the front end anywhere, it is used in the CMS and the default of "Your Site Title" isn't appropriate.
