### PR TITLE
FIX redirection of changed URLs issue#34

### DIFF
--- a/code/controllers/MultisitesFrontController.php
+++ b/code/controllers/MultisitesFrontController.php
@@ -53,26 +53,32 @@ class MultisitesFrontController extends ModelAsController {
 			// use OldPageRedirector if it exists, to find old page
 			if(class_exists('OldPageRedirector')){
 				if($redirect = OldPageRedirector::find_old_page(array($segment), Multisites::inst()->getCurrentSite())){
-					$redirect = SiteTree::get_by_link($url);
+					$redirect = SiteTree::get_by_link($redirect);
 				}
 			}else{
 				$redirect = self::find_old_page($segment, $site);			
 			}			
 
 			if($redirect) {
-				$this->response->redirect(
-					Controller::join_links(
+				$getVars = $request->getVars();
+				//remove the url var as it confuses the routing
+				unset($getVars['url']);
+				
+				$url = Controller::join_links(
 						$redirect->Link(
 							Controller::join_links(
 								$request->param('Action'),
 								$request->param('ID'),
 								$request->param('OtherID')
 							)
-						),
-						http_build_query($request->getVars())
-					),
-					301
-				);
+						)
+					);
+				
+				if(!empty($getVars)){
+					$url .= '?' . http_build_query($getVars);
+				}
+				
+				$this->response->redirect($url, 301);
 
 				return $this->response;
 			}


### PR DESCRIPTION
Fix for issue #34
Changed uninitialized $url to $redirect.
Move http_build_query() so it appends the variables as get parameters instead of as URL segments.
