### PR TITLE
fix(Multisites): #83 Stop getCurrentSiteId() stripping the port from the host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+/composer.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+**2017-11-16**
+
+* Stopped Multisites::getCurrentSiteId() stripping the port from the host
+
 **2017-11-10**
 
 * Updated to SilverStripe 4 compatibility

--- a/src/Multisites.php
+++ b/src/Multisites.php
@@ -189,6 +189,9 @@ class Multisites
 
         $parts = parse_url($host);
         $host  = "{$parts['scheme']}://{$parts['host']}";
+        if (isset($parts['port'])) {
+            $host .= ":{$parts['port']}";
+        }
 
         if ($this->map) {
             if (isset($this->map['hosts'][$host])) {


### PR DESCRIPTION
Fixes #83 

I did start trying to add a unit test for it, but I can't figure out how to make PHPUnit actually run the existing tests as a starting point. Any pointers there welcome.

The project we are using it on is using SilverStripe 3.6.x so restricted to Multisites 4.0.x so I have to make this branch (https://github.com/symbiote/silverstripe-multisites/compare/master...BiffBangPow:issue-83-stop-stripping-port-from-host-for-4.0.x|) for our own use. Is there anyway of getting that merged and released as a 4.0.5 version?