### PR TITLE
[Fix] Publishing ErrorPages from wrong domain.

### DIFF
--- a/client/css/MultisitesErrorPage.css
+++ b/client/css/MultisitesErrorPage.css
@@ -1,0 +1,28 @@
+
+/* Used in MultisitesErrorPageExtension */
+.MultisitesErrorPage_NoPubMsg {
+    margin: -5px 0 20px 0;
+    padding: 5px 8px 5px 8px;
+    border-radius: 3px;
+    border: 1px solid #da273b;
+    color: #da273b;
+    text-align: center;
+}
+
+/* Used in MultisitesErrorPageExtension */
+.MultisitesErrorPage_NoPubBtn {
+    padding: 5px 8px 5px 8px;
+    border-radius: 0 3px 3px 0;
+    color: #da273b;
+    border: 1px solid #da273b;
+    border-left: none;
+    pointer-events: none;
+    cursor: none;
+
+    -webkit-touch-callout: none; /* iOS Safari */
+    -webkit-user-select: none; /* Safari */
+    -khtml-user-select: none; /* Konqueror HTML */
+    -moz-user-select: none; /* Firefox */
+    -ms-user-select: none; /* Internet Explorer/Edge */
+    user-select: none; /* Chrome and Opera */
+}

--- a/src/Extension/MultisitesErrorPageExtension.php
+++ b/src/Extension/MultisitesErrorPageExtension.php
@@ -1,22 +1,71 @@
 <?php
-
 namespace Symbiote\Multisites\Extension;
 
 use Symbiote\Multisites\Multisites;
-use SilverStripe\CMS\Model\SiteTreeExtension;
+use SilverStripe\Core\Extension;
+use SilverStripe\View\Requirements;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\LiteralField;
 
 /**
  * Publishes separate static error pages for each site.
+ * Also prevents publishing of error pages on domains that the 
+ * user isn't logged into.
  *
  * @package silverstripe-multisites
  */
-class MultisitesErrorPageExtension extends SiteTreeExtension
+class MultisitesErrorPageExtension extends Extension
 {
+    public function __construct() {
+        Requirements::css("symbiote/silverstripe-multisites: client/css/MultisitesErrorPage.css");
+    }
 
     public function updateErrorFilename(&$name, $statusCode)
     {
         if ($site = Multisites::inst()->getActiveSite()) {
             $name = str_replace('error-', 'error-'.$site->Host.'-', $name);
+        }
+    }
+
+    public function canPublish($member = null)
+    {
+        //only allow publish if user logged into page's domain.
+        $parent = $this->owner->parent;
+        $siteID = $parent ? $parent->ID : null;
+        $multiID = Multisites::inst()->getCurrentSiteId();
+
+        if ($siteID == $multiID) {
+            return true;
+        }
+
+        //this actually removes the publish btn
+        return false;
+    }
+
+    public function updateCMSFields($fields)
+    {
+        //if cant publish (see canPublish)
+        if (!$this->canPublish()) {
+            //attach message above page title informing authors
+            $url = $this->owner->parent->Link();
+            $nopubmsg = new LiteralField(
+                "nopubmsg",
+                '<div class="MultisitesErrorPage_NoPubMsg">To publish this page, you need to log in via: <em>' . $url . '</em></div>'
+            );
+            $fields->insertBefore("Title", $nopubmsg);
+        }
+    }
+
+    public function updateCMSActions($actions)
+    {
+        //if cant publish (see canPublish)
+        if (!$this->canPublish()) {
+            //mimic publish button with a disabled appearance
+            $nopubbtn = new LiteralField(
+                "nopubbtn",
+                '<div class="MultisitesErrorPage_NoPubBtn font-icon-rocket"> Publish</div>'
+            );
+            $actions->insertAfter("action_save", $nopubbtn);
         }
     }
 }


### PR DESCRIPTION
- Prevents publishing of an ErrorPage when logged in via another domain.
- Shows warning and disabled publish button when on another domain's ErrorPage.
- Extension type for MultisitesErrorPageExtension changes to 'Extension'.