### PR TITLE
fix(ModelAdmin): Workaround for silverstripe-recipe 4.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
 	"require":
 	{
 		"silverstripe/cms": "~4.0",
+		"silverstripe/admin": "^4.3",
 		"symbiote/silverstripe-multivaluefield": "~5.0"
 	},
     "require-dev": {
@@ -24,7 +25,7 @@
         ],
 		"installer-name": "multisites",
 		"branch-alias": {
-			"dev-master": "5.0.x-dev"
+			"dev-master": "5.2.x-dev"
 		}
 	},
 	"replace": {


### PR DESCRIPTION
Solves: https://github.com/symbiote/silverstripe-multisites/issues/96

- Primary takeaway: this allows a site to use multisites with silverstripe-recipe 4.3.0
- Silverstripe-recipe 4.3.0 introduced changes that broke the previous approach to retrieving the model class.
- This will be fixed in silverstripe-recipe 4.3.1 (really silverstripe-admin 1.3.1).
- Don't want to require a specific version of ss-admin as it will create composer conflicts.
- This commit changes multisites to only work with ss-recipe >= 4.3.0
- When using ss-recipe 4.3.0:
  - An error will be thrown if you use the MultisitesAware extension.
  - Else MultisitesAware will be bypassed.
- Will work with ss-recipe >= 4.3.1 (other potential issues asside).