### PR TITLE
fix(deprecateError): Function create_function is deprecated in php7.2

### DIFF
--- a/src/Form/SiteSearchForm.php
+++ b/src/Form/SiteSearchForm.php
@@ -34,12 +34,13 @@ class SiteSearchForm extends SearchForm
 
         $keywords = $data['Search'];
 
-        $andProcessor = create_function('$matches', '
-	 		return " +" . $matches[2] . " +" . $matches[4] . " ";
-	 	');
-        $notProcessor = create_function('$matches', '
-	 		return " -" . $matches[3];
-	 	');
+        $andProcessor = function ($matches) {
+            return " +" . $matches[2] . " +" . $matches[4] . " ";
+        };
+
+        $notProcessor = function ($matches) {
+            return " -" . $matches[3];
+        };
 
         $keywords = preg_replace_callback('/()("[^()"]+")( and )("[^"()]+")()/i', $andProcessor, $keywords);
         $keywords = preg_replace_callback('/(^| )([^() ]+)( and )([^ ()]+)( |$)/i', $andProcessor, $keywords);


### PR DESCRIPTION
For PhP 7.2 and above function create_function() is deprecated. This is now fixed using anonymous function. 