### PR TITLE
Fix Site class reference

### DIFF
--- a/src/Admin/MultisitesCmsMainExtension.php
+++ b/src/Admin/MultisitesCmsMainExtension.php
@@ -104,7 +104,7 @@ class MultisitesCMSMainExtension extends LeftAndMainExtension {
         $classNameField = $form->Fields()->dataFieldByName('ClassName');
         if ($classNameField) {
             $className = $classNameField->Value();
-            if ($className === 'Site') 
+            if ($className === Site::class) 
             {
             	$form->Fields()->removeByName(array(SilverStripeNavigator::class));
                 $form->removeExtraClass('cms-previewable');


### PR DESCRIPTION
String 'Site' will not work with the current setup in SS4 anymore, so this check always fails, resulting in the preview not being hidden as intended.