### PR TITLE
Replace ClassName usage with text

### DIFF
--- a/src/Admin/MultisitesCmsMainExtension.php
+++ b/src/Admin/MultisitesCmsMainExtension.php
@@ -106,7 +106,7 @@ class MultisitesCMSMainExtension extends LeftAndMainExtension {
             $className = $classNameField->Value();
             if ($className === Site::class) 
             {
-            	$form->Fields()->removeByName(array(SilverStripeNavigator::class));
+            	$form->Fields()->removeByName(['SilverStripeNavigator']);
                 $form->removeExtraClass('cms-previewable');
             }
         }


### PR DESCRIPTION
Change: Minor

updateEditForm was incorrectly using a ClassName to search for a field. The SilverStripeNavigator field was no longer being removed, which allowed the page to be previewed (causing it to be redirected away seconds after loading). I've updated this field removal, and can see the preview now being correctly disabled.

This issue was found in a project running framework v4.3.0.